### PR TITLE
Compatibility of RenderTypePatch: not override renderType()

### DIFF
--- a/src/main/java/me/antileaf/signature/card/AbstractSignatureCard.java
+++ b/src/main/java/me/antileaf/signature/card/AbstractSignatureCard.java
@@ -403,40 +403,41 @@ public abstract class AbstractSignatureCard extends CustomCard {
 			SpireSuper.call(sb, x, y);
 	}
 
-	@SpireOverride
-	protected void renderType(SpriteBatch sb) {
-		if (!SignatureHelperInternal.shouldUseSignature(this)) {
-			SpireSuper.call(sb);
-			return;
-		}
+	// Moved to SignaturePatch.
+	// @SpireOverride
+	// protected void renderType(SpriteBatch sb) {
+	// 	if (!SignatureHelperInternal.shouldUseSignature(this)) {
+	// 		SpireSuper.call(sb);
+	// 		return;
+	// 	}
 
-		String text;
-		if (this.type == AbstractCard.CardType.ATTACK)
-			text = AbstractCard.TEXT[0];
-		else if (this.type == AbstractCard.CardType.SKILL)
-			text = AbstractCard.TEXT[1];
-		else if (this.type == AbstractCard.CardType.POWER)
-			text = AbstractCard.TEXT[2];
-		else if (this.type == AbstractCard.CardType.CURSE)
-			text = AbstractCard.TEXT[3];
-		else if (this.type == AbstractCard.CardType.STATUS)
-			text = AbstractCard.TEXT[7];
-		else
-			text = AbstractCard.TEXT[5];
+	// 	String text;
+	// 	if (this.type == AbstractCard.CardType.ATTACK)
+	// 		text = AbstractCard.TEXT[0];
+	// 	else if (this.type == AbstractCard.CardType.SKILL)
+	// 		text = AbstractCard.TEXT[1];
+	// 	else if (this.type == AbstractCard.CardType.POWER)
+	// 		text = AbstractCard.TEXT[2];
+	// 	else if (this.type == AbstractCard.CardType.CURSE)
+	// 		text = AbstractCard.TEXT[3];
+	// 	else if (this.type == AbstractCard.CardType.STATUS)
+	// 		text = AbstractCard.TEXT[7];
+	// 	else
+	// 		text = AbstractCard.TEXT[5];
 
-		BitmapFont font = FontHelper.cardTypeFont;
-		font.getData().setScale(this.drawScale);
-		this.getTypeColor().a = this.getRenderColor().a;
+	// 	BitmapFont font = FontHelper.cardTypeFont;
+	// 	font.getData().setScale(this.drawScale);
+	// 	this.getTypeColor().a = this.getRenderColor().a;
 
-		if (this.hideFrame())
-			this.getTypeColor().a *= this.getSignatureTransparency();
+	// 	if (this.hideFrame())
+	// 		this.getTypeColor().a *= this.getSignatureTransparency();
 
-		if (this.getTypeColor().a > 0.0F) {
-			FontHelper.renderRotatedText(sb, font, text, this.current_x,
-					this.current_y - 195.0F * this.drawScale * Settings.scale,
-					0.0F,
-					-1.0F * this.drawScale * Settings.scale,
-					this.angle, false, this.getTypeColor());
-		}
-	}
+	// 	if (this.getTypeColor().a > 0.0F) {
+	// 		FontHelper.renderRotatedText(sb, font, text, this.current_x,
+	// 				this.current_y - 195.0F * this.drawScale * Settings.scale,
+	// 				0.0F,
+	// 				-1.0F * this.drawScale * Settings.scale,
+	// 				this.angle, false, this.getTypeColor());
+	// 	}
+	// }
 }

--- a/src/main/java/me/antileaf/signature/card/AbstractSignatureCard.java
+++ b/src/main/java/me/antileaf/signature/card/AbstractSignatureCard.java
@@ -404,40 +404,40 @@ public abstract class AbstractSignatureCard extends CustomCard {
 	}
 
 	// Moved to SignaturePatch.
-	// @SpireOverride
-	// protected void renderType(SpriteBatch sb) {
-	// 	if (!SignatureHelperInternal.shouldUseSignature(this)) {
-	// 		SpireSuper.call(sb);
-	// 		return;
-	// 	}
+	@Deprecated // @SpireOverride
+	protected void renderType(SpriteBatch sb) {
+		if (!SignatureHelperInternal.shouldUseSignature(this)) {
+			SpireSuper.call(sb);
+			return;
+		}
 
-	// 	String text;
-	// 	if (this.type == AbstractCard.CardType.ATTACK)
-	// 		text = AbstractCard.TEXT[0];
-	// 	else if (this.type == AbstractCard.CardType.SKILL)
-	// 		text = AbstractCard.TEXT[1];
-	// 	else if (this.type == AbstractCard.CardType.POWER)
-	// 		text = AbstractCard.TEXT[2];
-	// 	else if (this.type == AbstractCard.CardType.CURSE)
-	// 		text = AbstractCard.TEXT[3];
-	// 	else if (this.type == AbstractCard.CardType.STATUS)
-	// 		text = AbstractCard.TEXT[7];
-	// 	else
-	// 		text = AbstractCard.TEXT[5];
+		String text;
+		if (this.type == AbstractCard.CardType.ATTACK)
+			text = AbstractCard.TEXT[0];
+		else if (this.type == AbstractCard.CardType.SKILL)
+			text = AbstractCard.TEXT[1];
+		else if (this.type == AbstractCard.CardType.POWER)
+			text = AbstractCard.TEXT[2];
+		else if (this.type == AbstractCard.CardType.CURSE)
+			text = AbstractCard.TEXT[3];
+		else if (this.type == AbstractCard.CardType.STATUS)
+			text = AbstractCard.TEXT[7];
+		else
+			text = AbstractCard.TEXT[5];
 
-	// 	BitmapFont font = FontHelper.cardTypeFont;
-	// 	font.getData().setScale(this.drawScale);
-	// 	this.getTypeColor().a = this.getRenderColor().a;
+		BitmapFont font = FontHelper.cardTypeFont;
+		font.getData().setScale(this.drawScale);
+		this.getTypeColor().a = this.getRenderColor().a;
 
-	// 	if (this.hideFrame())
-	// 		this.getTypeColor().a *= this.getSignatureTransparency();
+		if (this.hideFrame())
+			this.getTypeColor().a *= this.getSignatureTransparency();
 
-	// 	if (this.getTypeColor().a > 0.0F) {
-	// 		FontHelper.renderRotatedText(sb, font, text, this.current_x,
-	// 				this.current_y - 195.0F * this.drawScale * Settings.scale,
-	// 				0.0F,
-	// 				-1.0F * this.drawScale * Settings.scale,
-	// 				this.angle, false, this.getTypeColor());
-	// 	}
-	// }
+		if (this.getTypeColor().a > 0.0F) {
+			FontHelper.renderRotatedText(sb, font, text, this.current_x,
+					this.current_y - 195.0F * this.drawScale * Settings.scale,
+					0.0F,
+					-1.0F * this.drawScale * Settings.scale,
+					this.angle, false, this.getTypeColor());
+		}
+	}
 }

--- a/src/main/java/me/antileaf/signature/patches/card/SignaturePatch.java
+++ b/src/main/java/me/antileaf/signature/patches/card/SignaturePatch.java
@@ -362,48 +362,39 @@ public class SignaturePatch {
 		}
 	}
 
-	@SpirePatch(clz = AbstractCard.class, method = "renderType",
-			paramtypez = {SpriteBatch.class})
-	public static class RenderTypePatch {
-		@SpirePrefixPatch
-		public static SpireReturn<Void> Prefix(AbstractCard _inst, SpriteBatch sb) {
-			if (SignatureHelperInternal.usePatch(_inst)) {
-				if (getFrame(_inst) != null) {
-					String text;
-					if (_inst.type == AbstractCard.CardType.ATTACK)
-						text = AbstractCard.TEXT[0];
-					else if (_inst.type == AbstractCard.CardType.SKILL)
-						text = AbstractCard.TEXT[1];
-					else if (_inst.type == AbstractCard.CardType.POWER)
-						text = AbstractCard.TEXT[2];
-					else if (_inst.type == AbstractCard.CardType.CURSE)
-						text = AbstractCard.TEXT[3];
-					else if (_inst.type == AbstractCard.CardType.STATUS)
-						text = AbstractCard.TEXT[7];
-					else
-						text = AbstractCard.TEXT[5];
+    @SpirePatch2(clz = AbstractCard.class, method = "renderType")
+    public static class RenderTypePatch {
+        @SpireInsertPatch(locator = Locator.class, localvars = { "text", "font" })
+        public static SpireReturn<Void> Insert(AbstractCard __instance, SpriteBatch sb,
+                String text, BitmapFont font) {
 
-					BitmapFont font = FontHelper.cardTypeFont;
-					font.getData().setScale(_inst.drawScale);
-					getTypeColor(_inst).a = getRenderColor(_inst).a;
+            if (!SignatureHelperInternal.usePatch(__instance))
+                return SpireReturn.Continue();
 
-					if (SignatureHelperInternal.getInfo(_inst.cardID).hideFrame.test(_inst))
-						getTypeColor(_inst).a *= getSignatureTransparency(_inst);
+            if (getFrame(__instance) != null) {
+                Color typeColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "typeColor");
+                Color renderColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "renderColor");
 
-					if (getTypeColor(_inst).a > 0.0F) {
-						FontHelper.renderRotatedText(sb, font, text, _inst.current_x,
-								_inst.current_y - 195.0F * _inst.drawScale * Settings.scale,
-								0.0F,
-								-1.0F * _inst.drawScale * Settings.scale,
-								_inst.angle, false, getTypeColor(_inst));
-					}
-				}
+                typeColor.a = renderColor.a;
+                if ((SignatureHelperInternal.getInfo(__instance.cardID)).hideFrame.test(__instance))
+                    typeColor.a *= getSignatureTransparency(__instance);
+                if (typeColor.a > 0.0F)
+                    FontHelper.renderRotatedText(sb, font, text, __instance.current_x,
+                            __instance.current_y - 195.0F * __instance.drawScale * Settings.scale,
+                            0.0F, -1.0F * __instance.drawScale * Settings.scale, __instance.angle,
+                            false, typeColor);
+            }
 
-				return SpireReturn.Return();
-			}
+            return SpireReturn.Return();
+        }
 
-			return SpireReturn.Continue();
-		}
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                return LineFinder.findInOrder(ctMethodToPatch,
+                        new Matcher.MethodCallMatcher(FontHelper.class, "renderRotatedText"));
+            }
+        }
 	}
 
 	@SpirePatch(clz = AbstractCard.class, method = "renderEnergy",


### PR DESCRIPTION
因为我的模组需要改变renderType中的text，增加除了Attack/Skill/Power/Status/Curse以外的卡牌类型
但是我又不想要在你的RenderTypePatch之上再用PrefixPatch整个覆写一次
所以我想问你能不能将RenderTypePatch改成InsertPatch，就像我commit的这样
基本上效果是一样的，只是不确定会不会有其他模组的相容性问题
不过如果有其他模组想patch AbstractCard.renderType()，照你原本的写法应该也只能用PrefixPatch或者SpireOverride覆写，所以应该没差